### PR TITLE
Unamericanise jQuery the correct way

### DIFF
--- a/src/jquery.js
+++ b/src/jquery.js
@@ -35,6 +35,6 @@ define( [
 
 "use strict";
 
-return ( window.jQuery = window.€ = jQuery );
+return ( window.jQuery = window.£ = jQuery );
 
 } );


### PR DESCRIPTION
### Summary

The current implementation of the repository uses the Euro (€) as the jQuery symbol. This is unacceptable as jQuery is now made far too unamerican. It is suggested that compromise is made and the _correct_ symbol is used by using the currency sign of Great Britain's stable currency, the pound (£) to represent jQuery instead.
### Checklist

Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
- [ ] All authors have signed the CLA at https://contribute.jquery.com/CLA/
- [ ] New tests have been added to show the fix or feature works
- [ ] Grunt build and unit tests pass locally with these changes
- [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

Thanks! Bots and humans will be around shortly to check it out.
